### PR TITLE
fixing deploy CICD file parameter -auto-aprove terraform apply

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -35,4 +35,4 @@ jobs:
         $COMMAND_IAC init
         $COMMAND_IAC validate
         $COMMAND_IAC plan
-        $COMMAND_IAC apply auto-aprove
+        $COMMAND_IAC apply -auto-aprove


### PR DESCRIPTION
adding dash signal before auto-aprove option